### PR TITLE
Removing image change trigger from Jenkins-s2i to stop redeploy on rerunning ansible

### DIFF
--- a/jenkins-s2i-template.json
+++ b/jenkins-s2i-template.json
@@ -27,9 +27,6 @@
                     },
                     {
                         "type": "ConfigChange"
-                    },
-                    {
-                        "type": "ImageChange"
                     }
                 ],
                 "runPolicy": "Serial",


### PR DESCRIPTION
A problem we encountered was that Jenkins would redeploy every time the oc apply would occur with the ansible scripts. We found that removing the image change trigger from the build config stopped this issue.

To test this, apply the template using an ansible script or manually. When the Jenkins environment is up, add a dummy job to it. Then re-apply the template and see that Jenkins was not redeployed and the same dummy job should be there.

/cc @oybed @sherl0cks @InfoSec812 @mdanter 